### PR TITLE
init system detection addition

### DIFF
--- a/stork-deploy/src/main/java/com/fizzed/stork/deploy/Targets.java
+++ b/stork-deploy/src/main/java/com/fizzed/stork/deploy/Targets.java
@@ -88,7 +88,7 @@ public class Targets {
                 .command("sh").args("-c", 
                     "if $(/sbin/init --version | egrep -q 'upstart'); then echo upstart; " +
                     "elif $(systemctl | egrep -q '.mount'); then echo systemd; " +
-                    "elif [ -f /etc/init.d/cron ]; then echo sysv; " +
+                    "elif [ -f /etc/init.d/cron ] || [ -f /etc/init.d/crond ]; then echo sysv; " +
                     "else echo unknown; fi")
                 .pipeOutput(Streamables.captureOutput())
                 .pipeError(Streamables.nullOutput())


### PR DESCRIPTION
Adding detection for /etc/init.d/crond when checking for sysv init system

I'm running RHEL 5 and 6, and both only contain

```/etc/init.d/crond```

There is no

```/etc/init.d/cron```

Init system detection fails and falls back to UNKNOWN, meaning I can't deploy at all. I simply added an additional check for the crond file. Everything works fine for me after that, and it shouldn't negatively impact any systems that do contain the cron variant.