### PR TITLE
Allow APP_HOME to be used into java & app args

### DIFF
--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/linux/script-header.ftl
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/linux/script-header.ftl
@@ -11,6 +11,38 @@
 #
 
 #
+# working directory
+#
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ] ; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# save current working directory
+INITIAL_WORKING_DIR="`pwd`"
+
+# change working directory to app home
+PRGDIR=$(dirname "$PRG")
+cd "$PRGDIR/.."
+
+# application home is now current directory
+APP_HOME="`pwd`"
+
+# revert to initial working directory?
+if [ "$WORKING_DIR_MODE" = "RETAIN" ]; then
+  cd "$INITIAL_WORKING_DIR"
+fi
+
+#
 # settings
 # either change default in here OR just pass in as environment variable to
 # override the default value here
@@ -56,38 +88,6 @@ MAIN_CLASS="${config.mainClass}"
 [ -z "$DAEMON_MIN_LIFETIME" ] && DAEMON_MIN_LIFETIME="${config.daemonMinLifetime!""}"
 [ -z "$DAEMON_LAUNCH_CONFIRM" ] && DAEMON_LAUNCH_CONFIRM="${config.daemonLaunchConfirm!""}"
 </#if>
-
-#
-# working directory
-#
-
-# resolve links - $0 may be a softlink
-PRG="$0"
-
-while [ -h "$PRG" ] ; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
-
-# save current working directory
-INITIAL_WORKING_DIR="`pwd`"
-
-# change working directory to app home
-PRGDIR=$(dirname "$PRG")
-cd "$PRGDIR/.."
-
-# application home is now current directory
-APP_HOME="`pwd`"
-
-# revert to initial working directory?
-if [ "$WORKING_DIR_MODE" = "RETAIN" ]; then
-  cd "$INITIAL_WORKING_DIR"
-fi
 
 
 isAbsolutePath()

--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-header.ftl
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-header.ftl
@@ -12,6 +12,28 @@
 @REM
 
 @REM
+@REM working directory setup
+@REM
+
+set INITIAL_WORKING_DIR=%CD%
+
+SET SCRIPTPATH=%~dp0
+SET SCRIPTPATH=%SCRIPTPATH:~0,-1%
+set APP_HOME_REL=%SCRIPTPATH%\..
+@REM echo app_home_relative %APP_HOME_REL%
+
+@REM do we need to change the current working directory?
+if %WORKING_DIR_MODE%==APP_HOME (
+    pushd %APP_HOME_REL%
+    set APP_HOME=.
+) else (
+    @REM echo temporarily change working directory to get good abs path
+    pushd %APP_HOME_REL%
+    set APP_HOME=!CD!
+    popd
+)
+
+@REM
 @REM settings
 @REM
 
@@ -34,28 +56,6 @@ if "%BIN_DIR%"=="" set BIN_DIR=${config.binDir!""}
 if "%LIB_DIR%"=="" set LIB_DIR=${config.libDir!""}
 if "%APP_ARGS%"=="" set APP_ARGS=${config.appArgs}
 if "%JAVA_ARGS%"=="" set JAVA_ARGS=${config.javaArgs}
-
-@REM
-@REM working directory setup
-@REM
-
-set INITIAL_WORKING_DIR=%CD%
-
-SET SCRIPTPATH=%~dp0
-SET SCRIPTPATH=%SCRIPTPATH:~0,-1%
-set APP_HOME_REL=%SCRIPTPATH%\..
-@REM echo app_home_relative %APP_HOME_REL%
-
-@REM do we need to change the current working directory?
-if %WORKING_DIR_MODE%==APP_HOME (
-    pushd %APP_HOME_REL%
-    set APP_HOME=.
-) else (
-    @REM echo temporarily change working directory to get good abs path
-    pushd %APP_HOME_REL%
-    set APP_HOME=!CD!
-    popd
-)
 
 @REM setup remaining directories
 set APP_BIN_DIR=%APP_HOME%\%BIN_DIR%


### PR DESCRIPTION
Hello,

On an app I wanted to allow usage of $APP_HOME variables in lauchers.yml like this :
```yml
[...]
java_args: "-Dlog4j.configurationFile=$APP_HOME/conf/logging.xml"
[...]
```

To allow this behaviour, I move the APP_HOME directory detection before variables & constants initialisations.

Regards,
Antoine
