### PR TITLE
fix pop first app argument which caused main batch file to display "unsupported command line argument"

### DIFF
--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-daemon-jslwin.ftl
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-daemon-jslwin.ftl
@@ -25,8 +25,8 @@ if %bit64%==y set TargetExe=${config.name}64.exe
 @REM
 set ARG=
 for /F "tokens=1*" %%a in ("%APP_ARGS%") do (
-  set ARG=%%a
-  set APP_ARGS=%%b
+  set APP_ARGS=%%a
+  set ARG=%%b
 )
 
 IF "%ARG%"=="--run" (


### PR DESCRIPTION
when starting the main batch file <app>.bat with args
<app>.bat --start (or something else) and your configuration has
application arguments the application arguments are provided to the
commandline parsing routine and not the jslwin args provided on
commandline (--start, ...).
Switching APP_ARGS and ARG in the pop-function resolves this issue.