### PR TITLE
Added an option to attach tar.gz package as an artifact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,6 @@ To customize, the following properties are supported:
  - inputFiles: An array of input directories or files to compile in a single
    invocation.  Defaults to ${basedir}/src/main/launchers
 
- - attachArtifacts: If true the .tar.gz archive will be attached as an artifact to the maven build,
-   installed to the local repository and deployed to the remote in the deploy phase. Defaults false
-
 ### Configuration file
 
 ```yaml
@@ -400,6 +397,12 @@ To customize, the following properties are supported:
  - finalName: The final name of the assembly tarball -- as well as the name of
    the root directory contained within the tarball -- that will contain the 
    contents of stageDirectory. Defaults to ${project.build.finalName}
+   
+ - attachArtifacts: If true the .tar.gz archive will be attached as an artifact to the maven build,
+   installed to the local repository and deployed to the remote in the deploy phase. Defaults to false
+   
+ - classifier: Classifier used for the attached .tar.gz archive. Only relevant when attachArtifact is set to true.
+   Defaults to no classifier.
 
 
 ## Stork deploy

--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ To customize, the following properties are supported:
  - inputFiles: An array of input directories or files to compile in a single
    invocation.  Defaults to ${basedir}/src/main/launchers
 
+ - attachArtifacts: If true the .tar.gz archive will be attached as an artifact to the maven build,
+   installed to the local repository and deployed to the remote in the deploy phase. Defaults false
+
 ### Configuration file
 
 ```yaml

--- a/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
+++ b/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
@@ -9,11 +9,9 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 
 /**
  * Stages and assemble a maven project into a stork assembly tarball.
@@ -59,10 +57,24 @@ public class AssemblyMojo extends AbstractMojo {
      */
     @Parameter(property = "skipArtifactsThatAreDirectories", defaultValue = "false", required = true)
     protected Boolean skipArtifactsThatAreDirectories;
+
+    /**
+     * Attach artifacts to the maven build?
+     *
+     * @since 3.0.1
+     */
+    @Parameter(property = "attachArtifacts", defaultValue = "false", required = true)
+    protected Boolean attachArtifacts;
     
     @Parameter( defaultValue = "${project}", readonly = true )
     protected MavenProject project;
-    
+
+    /**
+     * The Maven project helper.
+     */
+    @Component
+    private MavenProjectHelper projectHelper;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!stageDirectory.exists()) {
@@ -137,7 +149,10 @@ public class AssemblyMojo extends AbstractMojo {
             // tarball it up
             File tgzFile = AssemblyUtils.createTGZ(outputDirectory, stageDirectory, finalName);
             getLog().info("Generated maven stork assembly: " + tgzFile);
-            
+
+            if (attachArtifacts) {
+                projectHelper.attachArtifact(project, "tar.gz", "stork", tgzFile);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }

--- a/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
+++ b/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
@@ -69,6 +69,15 @@ public class AssemblyMojo extends AbstractMojo {
      */
     @Parameter(property = "attachArtifacts", defaultValue = "false", required = true)
     protected Boolean attachArtifacts;
+
+    /**
+     * Classifier used for the Attached artifact
+     *
+     * @since 3.0.1
+     */
+    @Parameter(property = "classifier")
+    protected String classifier;
+
     
     @Parameter( defaultValue = "${project}", readonly = true )
     protected MavenProject project;
@@ -155,7 +164,7 @@ public class AssemblyMojo extends AbstractMojo {
             getLog().info("Generated maven stork assembly: " + tgzFile);
 
             if (attachArtifacts) {
-                projectHelper.attachArtifact(project, "tar.gz", "stork", tgzFile);
+                projectHelper.attachArtifact(project, "tar.gz", classifier, tgzFile);
             }
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);

--- a/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
+++ b/stork-maven-plugin/src/main/java/com/fizzed/stork/maven/AssemblyMojo.java
@@ -9,7 +9,11 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 


### PR DESCRIPTION
Currently the tar.gz archive of the stork assembly is not registered as an artifact and therefore not pushed to the repository in the deploy/release phase. I added an configruation parameter attachArtifacts which registers as an artifact if set to true. The default is false to keep the currently functionality the same.