### PR TITLE
params order is error

### DIFF
--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-daemon-jslwin.ftl
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-daemon-jslwin.ftl
@@ -25,8 +25,8 @@ if %bit64%==y set TargetExe=${config.name}64.exe
 @REM
 set ARG=
 for /F "tokens=1*" %%a in ("%APP_ARGS%") do (
-  set ARG=%%a
-  set APP_ARGS=%%b
+  set APP_ARGS=%%a
+  set ARG=%%b
 )
 
 IF "%ARG%"=="--run" (


### PR DESCRIPTION
```
if "%LOG_DIR%"=="" set LOG_DIR=${config.logDir!""}
if "%RUN_DIR%"=="" set RUN_DIR=${config.runDir!""}
if "%BIN_DIR%"=="" set BIN_DIR=${config.binDir!""}
if "%LIB_DIR%"=="" set LIB_DIR=${config.libDir!""}
if "%APP_ARGS%"=="" set APP_ARGS=${config.appArgs}
if "%EXTRA_APP_ARGS%"=="" set EXTRA_APP_ARGS=${config.extraAppArgs}
if "%JAVA_ARGS%"=="" set JAVA_ARGS=${config.javaArgs}
if "%EXTRA_JAVA_ARGS%"=="" set EXTRA_JAVA_ARGS=${config.extraJavaArgs}
```
config.appArgs is in first