### PR TITLE
Override JAVA_TOOL_OPTIONS when discovering java version

### DIFF
--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/linux/script-functions.sh
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/linux/script-functions.sh
@@ -195,7 +195,7 @@ getJavaVersion()
     #logJavaSearchDebug "getJavaVersion ver line: $java_ver_line"
     #echo `expr "'$java_ver_line'" : '.*version.*"\(.*\)"'`
     # extracts 1.8.0_144 or 9.0.1
-    local java_ver=`"$java_bin" -version 2>&1 | grep "version" | awk '{print $3}' | tr -d \"`
+    local java_ver=`JAVA_TOOL_OPTIONS='' "$java_bin" -version 2>&1 | grep "version" | awk '{print $3}' | tr -d \"`
     echo "$java_ver"
 }
 

--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-find-java.bat
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-find-java.bat
@@ -44,7 +44,7 @@ if NOT "%JAVA_HOME%"=="" (
 call :JavaSearchDebug "Searching PATH..."
 for %%X in (java.exe) do (set JAVA_IN_PATH=%%~$PATH:X)
 IF DEFINED JAVA_IN_PATH (
-    call :IsJavaBinVersionAcceptable !JAVA_IN_PATH! !target_java_ver_num! !target_java_ver_max! java_bin_accepted
+    call :IsJavaBinVersionAcceptable "!JAVA_IN_PATH!" !target_java_ver_num! !target_java_ver_max! java_bin_accepted
     if NOT "!java_bin_accepted!" == "" goto :AcceptableJavaBinFound
 )
 
@@ -166,6 +166,7 @@ GOTO:EOF
 :GetJavaBinMajorVersionNum
 setlocal
 SET java_bin=%~1
+SET JAVA_TOOL_OPTIONS=
 
 @REM echo getting ver for: %java_bin%
 

--- a/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-java.ftl
+++ b/stork-launcher/src/main/resources/com/fizzed/stork/launcher/windows/batch-java.ftl
@@ -6,7 +6,7 @@ set APP_CLASSPATH=%APP_LIB_DIR%\*;
 
 if "%LAUNCHER_DEBUG%"=="1" (
     echo ^[LAUNCHER^] java_classpath: %APP_CLASSPATH%
-    echo ^[LAUNCHER^] java_bin: %java_bin_accepted%
+    echo ^[LAUNCHER^] java_bin: "%java_bin_accepted%"
 )
 
 @REM append extra app and java args?


### PR DESCRIPTION
Adds quotes to variables in Batch scripts that failed with spaces in path.